### PR TITLE
Use Alpine as base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM ubuntu
+FROM alpine
 
-RUN apt update && apt install curl jq -y
+RUN apk add --update curl jq && \
+    rm -rf /var/cache/apk/*
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN  chmod +x /entrypoint.sh
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 ########################
 #
@@ -29,23 +29,23 @@ if [ -z "$ONLY_24" ]; then
   ONLY_24="true"
 fi
 
-if [ "$ONLY_24" == "false" ]; then
+if [ "$ONLY_24" = "false" ]; then
   echo "Processing all the logs"
 else 
   OLD_DATE=$(date -d '24 hours ago' +'%Y-%m-%dT%H:%M:%SZ')
   echo "Will only process 24hrs logs before or equal to $OLD_DATE"
 fi
 
-function error_msg () {
- echo -e "${C_RED}$*${C_RST}"
+error_msg () {
+ echo "${C_RED}$*${C_RST}"
 }
 
-function success_msg () {
- echo -e "${C_GRN}$*${C_RST}"
+success_msg () {
+ echo "${C_GRN}$*${C_RST}"
 }
 
-function info_msg () {
- echo -e "${C_BLU}$*${C_RST}"
+info_msg () {
+ echo "${C_BLU}$*${C_RST}"
 }
 
 clean_up () {
@@ -81,14 +81,19 @@ get_jobs_logs () {
   done
 }
 
+#########################
+##      Main
+#########################
+
+
 get_run_id
 # Check if there are any workflow runs
-if [[ "$TOTAL_COUNT" -eq 0 ]]; then
+if [ "$TOTAL_COUNT" -eq 0 ]; then
     error_msg "No workflow runs found."
     exit 1
 else
     get_job_id
-    if [[ -f $JOB_FILE ]]; then
+    if [ -f $JOB_FILE ]; then
      get_jobs_logs
      success_msg "Logs Downloaded and saved!"
      clean_up


### PR DESCRIPTION
- Using `alpine` as base image which reduce the final image size by ~100mb
- `sh` specific changes in script as `bash` is not available in `alpine` image